### PR TITLE
cf monoid

### DIFF
--- a/R/cf.R
+++ b/R/cf.R
@@ -124,12 +124,6 @@ cf_jackknife <- function (.cf = cf(), boot.l, cf.jackknife, jackknife.se) {
 #' @param cf Numeric matrix, original data for all observables and measurements.
 #' @param icf Numeric matrix, imaginary part of original data. Be very careful with this as most functions just ignore the imaginary part and drop it in operations. If it is not passed to this function, a matrix of `NA` will be created with the same dimension as `cf`.
 #'
-#' @details
-#'
-#' The following fields will also be made available:
-#'
-#' - `cf0`: Numeric vector, mean of original data.
-#'
 #' @family cf constructors
 #'
 #' @export
@@ -145,8 +139,6 @@ cf_orig <- function (.cf = cf(), cf, icf = NULL) {
   else {
     .cf$icf <- icf
   }
-
-  .cf$cf0 <- apply(.cf$cf, MARGIN = 2, FUN = mean)
 
   class(.cf) <- append(class(.cf), 'cf_orig')
   return (.cf)

--- a/man/pcModel.Rd
+++ b/man/pcModel.Rd
@@ -4,7 +4,7 @@
 \alias{pcModel}
 \title{Principal correlator two state model.}
 \usage{
-pcModel(par, t, T, delta1 = 1, t0)
+pcModel(par, t, T, delta1 = 1, reference_time)
 }
 \arguments{
 \item{par}{Numeric vector: Fit parameters of the model. In an
@@ -15,7 +15,7 @@ object of type \code{matrixfit}, this should be located at
 
 \item{T}{Numeric: Time extent of the lattice.}
 
-\item{t0}{Numeric: GEVP reference t0 value}
+\item{reference_time}{Numeric: GEVP reference time value in physical time convention}
 
 \item{sign.vec}{Numeric vector: Relative sign between forward and
 backwards propagating part. A plus makes it cosh, a minus makes it sinh.}


### PR DESCRIPTION
The various mixins that we have for the `cf`-class group several fields of the object. The `cf0` field still is not part of a mixin and is treated inconsistently throughout the various functions.

We had a discussion about allowing an empty `cf` object such that one can do this:

```r
corr <- cf()
for (elem in corr_list) {
    corr <- c.cf(corr, elem)
}
```

At the time I argued that this should rather be done with `do.call(c.cf, corr_list)` such that an empty `cf` object could be avoided. We do have this empty `cf` now, and it works for `c.cf`, but it does not work for `+.cf`.

Additionally we have this `cf0` field which is a strange beast. It contains the average over the original measurements. This can be computed from `cf` with `apply(mean, 2, cf)`. When one solves the GEVP on the bootstrap samples, there is no `cf` field left, we only have the bootstrap samples and the transformed `cf0`. So the `cf0` field is neither contained in `cf_orig` nor `cf_boot` nor `cf_jackknife` *exclusively*. I have the feeling that we need another mixin `cf_mean` in order to reflect that we have the means (or central values?).

A bit more abstractly we want that all `cf` objects are monoids with respect to certain binary operations, most importantly `+` and `c`. The above `for`-loop is a left fold (`foldl` in Haskell, `Reduce` in R). Both operations are a group and the `cf` class needs to be a group with a neutral element with respect to the operation.

We have the neutral element now, it is just `cf()`. And `c.cf` honors it, so we have the monoid (group without inverse) axioms:

- `c.cf(cf(), corr) == corr`
- `c.cf(corr, cf()) == corr`
- `c.cf(c.cf(corr1, corr2), corr3) == c.cf(corr1, c.cf(corr2, corr3))`

With `+.cf` and `add.cf` we do not have this, the neutral element would just give an error right now. So instead I need to do the following:

```r
corr_sum <- corr_list[[1]]
if (length(corr_list) > 1) {
    for (i in 2:length(corr_list)) {
        corr_sum <- corr_sum + corr_list[[i]]
    }
}
```

I would prefer if I can write this as a fold as I find that much more clear on intent:

```r
Reduce(`+.cf`, corr_list, cf())
```

The `cf0` field makes things more complicated. I just had a discussion with Johann and Markus and our conclusion is the following: There are certain operations that make sense on the original data (`+.cf`, `c.cf`, `addstat.cf`) and other that only make sense on bootstrapped data (`plot.cf`, `matrixfit`, …). Therefore the `cf0` should be part of the `cf_boot` mixin and `cf_orig` shall only have the `cf` and `icf` fields.

This makes it much easier to make functions like `c.cf` consistent with monoid axioms as one simply does not have to worry about `cf0`, it will be just dropped.

This pull request is not finished yet. Since we often have pull requests that are not finished yet, I'll add a tag for these situations such that we do not have to put “do not merge” at the top.