### PR TITLE
Do not draw zero length arrows

### DIFF
--- a/R/plotutils.R
+++ b/R/plotutils.R
@@ -188,7 +188,7 @@ plotwitherror <- function(x, y, dy, ylim, dx, xlim, mdx, mdy, errsum.method="lin
           start <- y[rw]+cumul.err[rw,(level-1)]
           end <- y[rw]+cumul.err[rw,level]
 
-          if (start != end) {
+          if (!is.na(start) && !is.na(end) && start != end) {
             arrows(x[rw], start, x[rw], end, length=arwhd.len, angle=90, code=2, col=clr)
             arwhd.len <- arwhd.len + 0.01
           }

--- a/R/plotutils.R
+++ b/R/plotutils.R
@@ -187,13 +187,11 @@ plotwitherror <- function(x, y, dy, ylim, dx, xlim, mdx, mdy, errsum.method="lin
         for(level in rng){
           start <- y[rw]+cumul.err[rw,(level-1)]
           end <- y[rw]+cumul.err[rw,level]
-          # arrows has a special behaviour here: when start==end, no arrow will be drawn,
-          # this can be exploited to plot points with different numbers of error bars in one go
-          # by supplying 0 errors for those points with fewer error bars
-          # In order to accomodate this, we don't increase
-          # the arrowhead line length in this case to prevent crazy looking error bars.
-          arrows(x[rw], start, x[rw], end, length=arwhd.len, angle=90, code=2, col=clr)
-          arwhd.len <- arwhd.len+0.01*as.numeric(start!=end)
+
+          if (start != end) {
+            arrows(x[rw], start, x[rw], end, length=arwhd.len, angle=90, code=2, col=clr)
+            arwhd.len <- arwhd.len + 0.01
+          }
         } 
         # for the linear.quadrature method, show the total error as a line of triple thickness
         # without drawing any "arrowstems"

--- a/man/plotwitherror.Rd
+++ b/man/plotwitherror.Rd
@@ -104,4 +104,12 @@ plotwitherror(x, y, dy, ylim, dx, xlim, mdx, mdy,
 }
 \author{Carsten Urbach, \email{urbach@hiskp.uni-bonn.de} \cr
         Bartosz Kostrzewa, \email{bartosz.kostrzewa@desy.de}}
+\examples{
+# Create some random data, set one error to zero.
+x <- 1:50
+y <- runif(50, 0, 1)
+dy <- runif(50, 0.1, 0.2)
+dy[4] <- 0
 
+plotwitherror(x, y, dy)
+}


### PR DESCRIPTION
See #60.

The logic for checking zero length arrows was in place already, so I have just skipped drawing of a zero length arrow. In the example one can see that the warning is not emitted any more.