### PR TITLE
Remove call to `data()` in example

### DIFF
--- a/man/bootstrap.analysis.Rd
+++ b/man/bootstrap.analysis.Rd
@@ -41,7 +41,6 @@ bootstrap.analysis(data, skip=0, boot.R=100, tsboot.sim="geom", pl=FALSE, boot.l
   that only data is kept in exact multiples of the block length.
 }
 \examples{
-data()
 data(plaq.sample)
 plaq.boot <- bootstrap.analysis(plaq.sample, pl=TRUE)
 }


### PR DESCRIPTION
In order to diagnose a build problem on Travis CI where the data could
not be found, we had added this as a diagnostic. It turned out that all
`.Rdata` files had been excluded in the `.Rbuildignore` due to a faulty
regular expression. This diagnostic is no longer needed and just
clutters the example.