### PR TITLE
Introduce testthat for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,10 @@ env:
     - R_CHECK_TIME="TRUE"
     - R_CHECK_TESTS="TRUE"
     - _R_CHECK_TIMINGS_="0"
+
+r_binary_packages:
+  - devtools
+  - roxygen2
+
+after_success:
+  - Rscript -e 'devtools::install(); devtools::test()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,14 @@ Maintainer: Carsten Urbach <urbach@hiskp.uni-bonn.de>
 SystemRequirements: Gnu Scientific Library version >= 1.8
 Description: Toolkit to extract hadronic quantities from Lattice QCD simulations. It contains functionality for IO, plotting, bootstrap and jackknife resampling, fitting, GEVP solving, error and autocorrelation estimation as well as other areas.
 Imports: boot
-Suggests: tikzDevice, minpack.lm, parallel, Rhdf5lib (>= 1.3.2), rhdf5, knitr
+Suggests: 
+    tikzDevice,
+    minpack.lm,
+    parallel,
+    Rhdf5lib (>= 1.3.2),
+    rhdf5,
+    knitr,
+    testthat
 License: GPL-3
 URL: https://github.com/urbach/hadron
 BugReports: https://github.com/urbach/hadron/issues

--- a/test
+++ b/test
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright © 2019 Martin Ueding <dev@martin-ueding.de>
+
+set -e
+set -u
+
+Rscript -e 'devtools::document(); devtools::test();'

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(hadron)
+
+test_check("hadron")

--- a/tests/testthat/test_dummy.R
+++ b/tests/testthat/test_dummy.R
@@ -1,0 +1,1 @@
+## Dummy test such that this directory exists.


### PR DESCRIPTION
We now have two pull requests that will use testthat. This pull request introduces it as a single pull request such that we do not get that many merge conflicts in `DESCRIPTION` later on. Unit tests are run on Travis CI as well.