### PR TITLE
Commit hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,8 @@ CI.
 
 Comments should be prefixed with `## ` whereas commented out code is prefixed
 with `# `.
+
+## Commit Hooks
+
+Please run the `./setup-devel` script before making a commit such that the
+appropriate commit hooks are in place.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -22,6 +22,6 @@ Rscript -e 'devtools::document();'
 git diff > "$diff_new"
 
 if ! diff -u "$diff_old" "$diff_new" &> /dev/null; then
-  echo "${red}Generating the documentation has changed the tree, try to commit again.${reset}" >&2
+  echo "${red}Generating the documentation has changed the tree, add them to the index and try to commit again.${reset}" >&2
   exit 2
 fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -18,7 +18,7 @@ git diff > "$diff_old"
 Rscript -e 'devtools::document();'
 git diff > "$diff_new"
 
-if diff -u "$diff_old" "$diff_new" &> /dev/null; then
+if ! diff -u "$diff_old" "$diff_new" &> /dev/null; then
   echo "Generating the documentation has changed the tree, try to commit again." >&2
   exit 2
 fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Copyright © 2019 Martin Ueding <dev@martin-ueding.de>
 
+# Builds the documentation with Roxygen and aborts the commit if the output of
+# `git diff` changes. This gives the user the opportunity to add the generated
+# changes and try to commit again.
+
 set -e
 set -u
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright © 2019 Martin Ueding <dev@martin-ueding.de>
+
+set -e
+set -u
+
+diff_old=$(mktemp)
+diff_new=$(mktemp)
+
+cleanup() {
+  rm -f "$diff_old"
+  rm -f "$diff_new"
+}
+
+trap cleanup EXIT
+
+git diff > "$diff_old"
+Rscript -e 'devtools::document();'
+git diff > "$diff_new"
+
+if diff -u "$diff_old" "$diff_new" &> /dev/null; then
+  echo "Generating the documentation has changed the tree, try to commit again." >&2
+  exit 2
+fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,6 +4,9 @@
 set -e
 set -u
 
+red="$(tput setaf 1)"
+reset="$(tput sgr0)"
+
 diff_old=$(mktemp)
 diff_new=$(mktemp)
 
@@ -19,6 +22,6 @@ Rscript -e 'devtools::document();'
 git diff > "$diff_new"
 
 if ! diff -u "$diff_old" "$diff_new" &> /dev/null; then
-  echo "Generating the documentation has changed the tree, try to commit again." >&2
+  echo "${red}Generating the documentation has changed the tree, try to commit again.${reset}" >&2
   exit 2
 fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -25,7 +25,7 @@ git diff > "$diff_old"
 Rscript -e 'devtools::document();'
 git diff > "$diff_new"
 
-if ! diff -u "$diff_old" "$diff_new" &> /dev/null; then
+if ! diff -q "$diff_old" "$diff_new" &> /dev/null; then
   echo "${red}Generating the documentation has changed the tree, add them to the index and try to commit again.${reset}" >&2
   exit 2
 fi

--- a/setup-devel
+++ b/setup-devel
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright © 2019 Martin Ueding <dev@martin-ueding.de>
+
+set -e
+set -u
+
+rm -rf .git/hooks
+cd .git
+ln -s ../hooks ./

--- a/setup-devel
+++ b/setup-devel
@@ -4,6 +4,14 @@
 set -e
 set -u
 
-rm -rf .git/hooks
 cd .git
-ln -s ../hooks ./
+
+if ! [[ -d hooks ]]; then
+  mkdir hooks
+fi
+
+cd hooks
+
+for hook in ../../hooks/*; do
+  ln -s "$hook" ./
+done


### PR DESCRIPTION
This addresses Issue #118.

Here I have changed something in a Roxygen comment and went straight to commit (`ca ...` is `git commit -a -m '...'`):

![auswahl_001](https://user-images.githubusercontent.com/976924/50906822-3ad71e00-1426-11e9-87ca-fef083ddfceb.png)

It also gives exit status 1, but I guess I am virtually the only one who has the return status in the next prompt. So I added red color to the error message.