### PR TITLE
Split off exponent for very large or small numbers

### DIFF
--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -29,6 +29,15 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
   N <- 0
   threshold <- 10^(digits-1)
 
+  base <- round(log10(x[1]))
+  split_base <- abs(base) > 19
+  if (split_base) {
+    x <- x / 10**base
+    if (!missing(dx)) {
+      dx <- dx / 10**base
+    }
+  }
+
   if(missing(dx) && lx < 2) {
     if( is.na(x) ) x <- 0.0
     ## just a number without error
@@ -89,11 +98,17 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
       else tmp <- paste(format(round(x, digits=N), nsmall=N, scientific=FALSE), "(", displayerr, ")", sep="")
     }
   }
-  ret <- tmp
-  if(with.dollar) {
-    ret <- paste("$", tmp, "$", sep="")
+  if (with.dollar) {
+    if (split_base) {
+      tmp <- paste0(tmp, '\\cdot 10^{', base, '}')
+    }
+    tmp <- paste0("$", tmp, "$")
+  } else {
+    if (split_base) {
+      tmp <- paste0(tmp, 'e', base)
+    }
   }
-  return(ret)
+  return (tmp)
 }
 
 escape_underscore <- function(x){

--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -29,7 +29,11 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
   N <- 0
   threshold <- 10^(digits-1)
 
-  base <- round(log10(x[1]))
+  if (is.na(x[1])) {
+    base <- 0
+  } else {
+    base <- round(log10(x[1]))
+  }
   split_base <- abs(base) > 19
   if (split_base) {
     x <- x / 10**base

--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -29,10 +29,10 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
   N <- 0
   threshold <- 10^(digits-1)
 
-  if (is.na(x[1])) {
+  if (!is.finite(x[1])) {
     base <- 0
   } else {
-    base <- round(log10(x[1]))
+    base <- round(log10(abs(x[1])))
   }
   split_base <- abs(base) > 19
   if (split_base) {

--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -35,7 +35,7 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
   if (!is.finite(x[1])) {
     base <- 0
   } else {
-    base <- round(log10(abs(x[1])))
+    base <- floor(log10(abs(x[1])))
   }
   split_base <- abs(base) > 19
   if (split_base) {

--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -29,6 +29,9 @@ tex.catwitherror <- function(x, dx, digits=1, with.dollar=TRUE, human.readable=T
   N <- 0
   threshold <- 10^(digits-1)
 
+  ## In case the number is very small, printing it with fixed point (`%f`) will
+  ## not work. For this case we divide out the exponent from both value and
+  ## error and attach it at the end.
   if (!is.finite(x[1])) {
     base <- 0
   } else {

--- a/tests/testthat/test_tex_catwitherror.R
+++ b/tests/testthat/test_tex_catwitherror.R
@@ -7,6 +7,13 @@ test_that('small_error', {
     expect_equal(tex.catwitherror(123, 1, digits = 1, with.dollar = FALSE), '123(1)')
 })
 
+test_that('very_small_number', {
+    expect_equal(tex.catwitherror(1.23e-20, 0.45e-20, digits = 2, with.dollar = FALSE), '1.23(45)e-20')
+    expect_equal(tex.catwitherror(1.23e-40, 0.45e-40, digits = 2, with.dollar = TRUE), '$1.23(45)\\cdot 10^{-40}$')
+
+    expect_equal(tex.catwitherror(1.23e-40, digits = 2, with.dollar = FALSE), '1.2e-40')
+})
+
 test_that('same_error', {
     expect_equal(tex.catwitherror(0.00123, 0.00123, digits = 4, with.dollar = FALSE), '0.001230(1230)')
     expect_equal(tex.catwitherror(12.345, 12.345, digits = 4, with.dollar = FALSE), '12.35(12.35)')


### PR DESCRIPTION
This fixes Issue #123.

I have added logic to split off the exponent for very large or small numbers. The following test cases probably best describe the behavior:

```r
    expect_equal(tex.catwitherror(1.23e-20, 0.45e-20, digits = 2, with.dollar = FALSE), '1.23(45)e-20')
    expect_equal(tex.catwitherror(1.23e-40, 0.45e-40, digits = 2, with.dollar = TRUE), '$1.23(45)\\cdot 10^{-40}$')

    expect_equal(tex.catwitherror(1.23e-40, digits = 2, with.dollar = FALSE), '1.2e-40')
```

I hope that this works for formatting arbitrary χ² values.