### PR TITLE
Add prior to bootnlsfit

### DIFF
--- a/R/bootstrap.nlsfit.R
+++ b/R/bootstrap.nlsfit.R
@@ -769,9 +769,6 @@ bootstrap.nlsfit <- function(fn,
     Y <- c(y, x)
     par.Guess <- c(par.guess, x)
     errormodel <- "xyerrors"
-    if( !is.null(c(priors$param, priors$p, priors$psamples)) ){
-      stop("Priors are not implemented in the errormodel xyerrors yet.")
-    }
   } else {
     stop("The provided bootstrap samples do not match the number of data points with errors. Make sure that the number of columns is either the length of `y` alone for just y-errors or the length of `y` and `x` for xy-errors.")
   }

--- a/R/bootstrap.nlsfit.R
+++ b/R/bootstrap.nlsfit.R
@@ -435,6 +435,7 @@ simple.nlsfit <- function(fn,
                           y,
                           x,
                           errormodel,
+                          priors = list(param = c(), p = c(), psamples = c()),
                           ...,
                           dy,
                           dx,
@@ -452,6 +453,15 @@ simple.nlsfit <- function(fn,
   stopifnot(!missing(x))
   stopifnot(!missing(par.guess))
   stopifnot(!missing(fn))
+  if(!is.null(priors$param)){
+    stopifnot(is.vector(priors$param))
+  }
+  stopifnot( length(priors$param) == length(priors$p) &&
+               length(priors$param) == ncolps &&
+               length(priors$p) == ncolps )
+  if( !is.null(c(priors$param, priors$p, priors$psamples)) ){
+    stop("Priors are not implemented in simple.nlsfit yet.")
+  }
 
   useCov <- !missing(CovMatrix)
 
@@ -478,7 +488,7 @@ simple.nlsfit <- function(fn,
   dy <- all.errors$dy
   dx <- all.errors$dx
 
-  wrapper <- set.wrapper(fn, gr, dfn, par.guess, errormodel, useCov, W, x, ipx, lm.avail, maxiter, success.infos, na.rm)
+  wrapper <- set.wrapper(fn, gr, dfn, par.guess, errormodel, useCov, W, x, ipx, lm.avail, maxiter, success.infos, na.rm, priors)
 
   ## now the actual fit is performed
   first.res <- wrapper(Y, par.Guess, ...)

--- a/R/bootstrap.nlsfit.R
+++ b/R/bootstrap.nlsfit.R
@@ -449,6 +449,11 @@ simple.nlsfit <- function(fn,
                           success.infos = 1:3,
                           relative.weights = FALSE,
                           na.rm = FALSE) {
+  if(!is.null(priors$psamples)) {
+    ncolps <- ncol(as.matrix(priors$psamples))
+  } else {
+    ncolps <- length(priors$psamples)
+  }
   stopifnot(!missing(y))
   stopifnot(!missing(x))
   stopifnot(!missing(par.guess))
@@ -699,7 +704,6 @@ bootstrap.nlsfit <- function(fn,
   } else {
     ncolps <- length(priors$psamples)
   }
-  dimps <- dim(priors$psamples)
   stopifnot(!missing(y))
   stopifnot(!missing(x))
   stopifnot(!missing(par.guess))


### PR DESCRIPTION
Hello Martin,

The n_particle fit routine with priors is implemented now for the 'yerrors' model (probably this is the only error model that I'll need in my analysis) with provided jacobians (gr) as well as without. Compared to the master branch, the only files I have changed are 'new_matrixfit.R' and 'bootstrap.nlsfit.R'.
The fits seem to work for a given Covariance Matrix (useCov = TRUE) as well as for no provided Matrix.

I am looking forward to your comments.

Cheers,
Niko