### PR TITLE
Example for uwerr.cf

### DIFF
--- a/R/cf.R
+++ b/R/cf.R
@@ -563,7 +563,7 @@ jackknife.cf <- function(cf, boot.l = 1) {
 #'         or `cf$icf`, the corresponding row of `uwcf` and/or `uwicf` will contain
 #'         `NA` for all members.
 #' 
-#' @example
+#' @examples
 #' x <- uwerr.cf(samplecf)
 #' summary(x)
 #' plot(x)

--- a/R/cf.R
+++ b/R/cf.R
@@ -563,6 +563,10 @@ jackknife.cf <- function(cf, boot.l = 1) {
 #'         or `cf$icf`, the corresponding row of `uwcf` and/or `uwicf` will contain
 #'         `NA` for all members.
 #' 
+#' @example
+#' x <- uwerr.cf(samplecf)
+#' summary(x)
+#' plot(x)
 uwerr.cf <- function(cf){
   stopifnot(inherits(cf, 'cf_orig'))
 

--- a/man/uwerr.cf.Rd
+++ b/man/uwerr.cf.Rd
@@ -24,3 +24,8 @@ or \code{cf$icf}, the corresponding row of \code{uwcf} and/or \code{uwicf} will 
 \description{
 Gamma method analysis on all time-slices in a 'cf' object
 }
+\examples{
+x <- uwerr.cf(samplecf)
+summary(x)
+plot(x)
+}


### PR DESCRIPTION
In #226 I raised that the `uwerr.cf` function is broken somehow. This adds an example such that this part of the code is exercised as part of the checks and that further failures will be caught earlier.