### PR TITLE
Treat warnings as errors on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: r
 dist: trusty
 sudo: required
 cache: packages
-warnings_are_errors: false
+warnings_are_errors: true
 use_bioc: true
 
 notifications:


### PR DESCRIPTION
Now we will get serious about a stable CRAN submission and enforce that
no new warnings will get in. We likely need to stabilize this branch
first, though.