### PR TITLE
test for failure mode in tex.catwitherror

### DIFF
--- a/R/tex-utils.R
+++ b/R/tex-utils.R
@@ -25,9 +25,9 @@ convert.scientific <- function(str, errstr) {
 ## given a value.
 absolute.number.digits <- function(x, digits){
   if(x == 0 || is.na(x)){
-    return(digits-1)
+    return(max(digits-1, 0))
   }else{
-    return(ceiling(digits-1-log10(abs(x))))
+    return(max(ceiling(digits-1-log10(abs(x))), 0))
   }
 }
 

--- a/tests/testthat/test_tex_catwitherror.R
+++ b/tests/testthat/test_tex_catwitherror.R
@@ -28,6 +28,11 @@ test_that('large_error', {
     expect_equal(tex.catwitherror(1.12345, 12.3, digits = 4, with.dollar = FALSE), '1.12(12.3)')
 })
 
+test_that('similar_error', {
+    expect_equal(tex.catwitherror(7492.8291130334482659, 1759.0859320695926726,
+                                  digits = 3, with.dollar = FALSE), '7492.829(090)')
+})
+
 test_that('no_error', {
     expect_equal(tex.catwitherror(0.00123, digits = 4, with.dollar = FALSE), '0.001230')
 })
@@ -44,6 +49,7 @@ test_that('zero_val_zero_err', {
 test_that('NA', {
     expect_equal(tex.catwitherror(NA, NA, digits = 4, with.dollar = FALSE), 'NA(NA)')
 })
+
 
 test_that('vector', {
     for (i in 1:10) {

--- a/tests/testthat/test_tex_catwitherror.R
+++ b/tests/testthat/test_tex_catwitherror.R
@@ -50,7 +50,6 @@ test_that('NA', {
     expect_equal(tex.catwitherror(NA, NA, digits = 4, with.dollar = FALSE), 'NA(NA)')
 })
 
-
 test_that('vector', {
     for (i in 1:10) {
         x <- runif(1)

--- a/tests/testthat/test_tex_catwitherror.R
+++ b/tests/testthat/test_tex_catwitherror.R
@@ -30,7 +30,7 @@ test_that('large_error', {
 
 test_that('similar_error', {
     expect_equal(tex.catwitherror(7492.8291130334482659, 1759.0859320695926726,
-                                  digits = 3, with.dollar = FALSE), '7492.829(090)')
+                                  digits = 3, with.dollar = FALSE), '7492(1759)')
 })
 
 test_that('no_error', {

--- a/tests/testthat/test_tex_catwitherror.R
+++ b/tests/testthat/test_tex_catwitherror.R
@@ -30,7 +30,7 @@ test_that('large_error', {
 
 test_that('similar_error', {
     expect_equal(tex.catwitherror(7492.8291130334482659, 1759.0859320695926726,
-                                  digits = 3, with.dollar = FALSE), '7492(1759)')
+                                  digits = 3, with.dollar = FALSE), '7493(1759)')
 })
 
 test_that('no_error', {


### PR DESCRIPTION
the recent changes to `tex.catwitherror` have resulted in `-1` being passed as `nsmall` to `format` for this kind of test case

```
x = 7492.8291130334482659
dx = 1759.0859320695926726
digits = 3
--> 112 N=-1
```