### PR TITLE
Use the error function from the fit in the plots

### DIFF
--- a/R/bootstrap.nlsfit.R
+++ b/R/bootstrap.nlsfit.R
@@ -1194,7 +1194,7 @@ print.bootstrapfit <- function(x, ..., digits = 2) {
 #'
 #' @export
 #' @family NLS fit functions
-plot.bootstrapfit <- function(x, ..., col.line="black", col.band="gray", opacity.band=0.65, lty=c(1), lwd=c(1), supports=1000, plot.range, error=sd) {
+plot.bootstrapfit <- function(x, ..., col.line="black", col.band="gray", opacity.band=0.65, lty=c(1), lwd=c(1), supports=1000, plot.range, error=x$error.function) {
   # The plot object might not have a mask, we want to have one in either case.
   if (is.null(x$mask)) {
     x$mask <- rep(TRUE, length(x$x))
@@ -1261,7 +1261,7 @@ residual_plot <- function (x, ...) {
 }
 
 #' @export
-residual_plot.bootstrapfit <- function (x, ..., error_fn = sd, operation = `/`) {
+residual_plot.bootstrapfit <- function (x, ..., error_fn = x$error.function, operation = `/`) {
   if (is.logical(x$mask)) {
     x$mask <- which(x$mask)
   }


### PR DESCRIPTION
I noticed that the error estimates in the residual plot are incorrect when using jackknife. The fit object knows the error function, but it does not use it. With bootstrap it looks like this:

![Bildschirmfoto_043](https://user-images.githubusercontent.com/976924/76072973-2befeb00-5f99-11ea-8a99-b82b90e4753f.png)

And the same fit looks like this with jackknife:

![Bildschirmfoto_044](https://user-images.githubusercontent.com/976924/76072975-2c888180-5f99-11ea-8d84-657223e6a2cf.png)

This pull request should fix that.