### PR TITLE
Only run the unit tests on Linux

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,10 @@
 library(testthat)
 library(hadron)
 
-test_check("hadron")
+# The developers of this package only use Linux or the Linux subsystem on
+# Windows. Therefore we do not want to invest time in getting all the unit
+# tests working on Windows. If the operating system is not linux, we just don't
+# run our unit tests.
+if (Sys.info()['sysname'] == 'Linux') {
+  test_check("hadron")
+}


### PR DESCRIPTION
As requested in Issue #273 this should disable the unit tests on Windows.