### PR TITLE
Define the old_handler locally

### DIFF
--- a/src/cdh.c
+++ b/src/cdh.c
@@ -5,8 +5,6 @@
 
 #include <math.h>
 
-gsl_error_handler_t *old_handler;
-
 void my_errhandler(const char *reason, const char *file, int line, int gsl_errno) {
   if (gsl_errno != GSL_EUNDRFLW) {
     error("ERROR: In GSL the following error occured: %s\nline %d of file %s\n",
@@ -373,6 +371,7 @@ SEXP cdh_c(SEXP rev,
   PROTECT(res = NEW_NUMERIC(2 * N));
   resp = NUMERIC_POINTER(res);
 
+  gsl_error_handler_t *old_handler;
   old_handler = gsl_set_error_handler(&my_errhandler);
 
   fscdh(revp[0],
@@ -442,6 +441,7 @@ SEXP cdhnew_c(SEXP rev,
   PROTECT(res = NEW_NUMERIC(2 * N));
   resp = NUMERIC_POINTER(res);
 
+  gsl_error_handler_t *old_handler;
   old_handler = gsl_set_error_handler(&my_errhandler);
 
   fscdhnew(revp[0],

--- a/src/tmcdh.c
+++ b/src/tmcdh.c
@@ -11,7 +11,6 @@
 #include <complex.h>
 #include <math.h>
 
-gsl_error_handler_t *old_handler;
 const double N = 16. * M_PI * M_PI;
 const double fmGeV = 0.1973269631;
 


### PR DESCRIPTION
I cannot compile the latest version of hadron (`d90509514e56c723e1f89d064829e00212545f01`) on my laptop any more. Recently I did the upgrade to the latest Fedora release and that brought a new GCC (and likely also new R). The same hadron version still works on QBIG, so it has to be either the environment or the newer GCC versions enforce more critically and therefore the code needs to be changed.

Version overview:

| Program | System | Version |
| --- | --- | --- |
| GCC | Martin | 10.1.1 20200507 |
| R | Martin | 3.6.3 (2020-02-29) |
| GCC | qbig | (Debian 6.3.0-18+deb9u1) 6.3.0 20170516 |
| R | qbig | 3.6.1 (2019-07-05) |

There is a linker error duing the compilation:

```text
   g++ -m64 -std=gnu++11 -shared -L/usr/lib64/R/lib -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -o hadron.so RcppExports.o alpha_s.o cdh.o firstPart.o gen_points_array.o inteSubFunc.o inv_cosh.o luscherZeta.o read_nissa_textcf_kernel.o secondPart.o spheHarmYlm.o thirdPart.o tmcdh.o zeta_function_R_interface.o -lgsl -lgslcblas -L/usr/lib64/R/lib -lR
   /usr/bin/ld: tmcdh.o:/home/mu/Lattice/Code/hadron/src/tmcdh.c:14: multiple definition of `old_handler'; cdh.o:/home/mu/Lattice/Code/hadron/src/cdh.c:8: first defined here
   collect2: error: ld returned 1 exit status
```

I have done a `git clean -dfx` and `autoreconf -fi`, so it is really is compiled from scratch on each machine.

We can search the codebase for `old_handler` and find that there twice actually:

```text
src/cdh.c:8:gsl_error_handler_t *old_handler;
src/tmcdh.c:14:gsl_error_handler_t *old_handler;
```

This definition does not have an `extern` or `static` qualifier. In C++ a non-`const` global variable would automatically be `extern`, whereas a `const` one could be `static` I believe. In C I am not sure, but apparently it is implicitly `static` and leads to the multiple definition.

In `cdh.c` the global variable is not really used in a global fashion. Rather the GSL error handler is stored locally and then reset. This could be done with a local variable easily. And then in `tmcdh.c` it is defined at the top of the file but never used anywhere else. It could just be removed.

I have gone ahead and performed these two changes. Now it compiles again.