### PR TITLE
Integrate hadronsampledata into hadron

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ LinkingTo:
     Rcpp
 Suggests: 
     dplyr,
+    hadronsampledata,
     minpack.lm,
     parallel,
     rhdf5,
@@ -52,3 +53,5 @@ RoxygenNote: 7.1.0
 Encoding: UTF-8
 Remotes: bioc::release/rhdf5
 VignetteBuilder: knitr
+Additional_repositories:
+    https://hiskp-lqcd.github.io/r-repo/


### PR DESCRIPTION
I have made the repository [hadron_example_data](https://github.com/HISKP-LQCD/hadron_example_data) into a real R package. It needs to be build using `R CMD build .` and deployed in a moment.

Then I have created a new repository [r-repo](https://github.com/HISKP-LQCD/r-repo) which will serve to hold the data for serving over HTTP. The example data package is then deployed via `drat::insertPackage('hadronexampledata_0.0.0.9000.tar.gz', repodir = '../r-repo/', action = 'prune')`. Go to the `r-repo`, commit and push.

At `r-repo` I have enabled *GitHub Pages* to serve the content at <https://hiskp-lqcd.github.io/r-repo/> such that we have our own R repository (like CRAN).

This pull request adds a little more meta data to hadron, such that one can do `install.packages('hadronexampledata')` after loading the hadron library. This seems to work just fine after installing and loading the version with the pull request:

```
> install.packages('hadronexampledata')
Installiere Paket nach ‘/home/mu/R/x86_64-redhat-linux-gnu-library/4.0’
(da ‘lib’ nicht spezifiziert)
versuche URL 'https://hiskp-lqcd.github.io/r-repo/src/contrib/hadronexampledata_0.0.0.9000.tar.gz'
Content type 'application/gzip' length 18625262 bytes (17.8 MB)
==================================================
downloaded 17.8 MB

* installing *source* package ‘hadronexampledata’ ...
** using staged installation
** inst
** help
No man pages found in package  ‘hadronexampledata’ 
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (hadronexampledata)

Die heruntergeladenen Quellpakete sind in 
        ‘/tmp/RtmpkeqDrH/downloaded_packages’
```

The data that was already present in the example data package was not in R format (Rdata/rds). As such I have moved it into the `inst` directory. One can now add more Rdata/rds files to that package and have it exported.

The size limit on GitHub is 1 GB, we should be able to use it even for larger files in this way.