### PR TITLE
support for multidimensional nlsfit [draft]

### DIFF
--- a/R/bootstrap.nlsfit.R
+++ b/R/bootstrap.nlsfit.R
@@ -110,7 +110,7 @@ parametric.nlsfit <- function (fn, par.guess, boot.R, y, dy, x, dx,
                                lower = rep(x = -Inf, times = length(par.guess)),
                                upper = rep(x = +Inf, times = length(par.guess)),
                                ..., bootstrap=TRUE) {
-  stopifnot(length(x) == length(y))
+  stopifnot(length(x) %% length(y) == 0)
   stopifnot(missing(dx) || length(dx) == length(x))
   stopifnot(missing(dy) || length(dy) == length(y))
   stopifnot(length(lower) == length(par.guess))
@@ -156,7 +156,7 @@ parametric.nlsfit.cov <- function (fn, par.guess, boot.R, y, x, cov,
                                    lower = rep(x = -Inf, times = length(par.guess)),
                                    upper = rep(x = +Inf, times = length(par.guess)),
                                    ..., bootstrap=TRUE, na.rm = FALSE) {
-  stopifnot(length(x) == length(y))
+  stopifnot(length(x) %% length(y) == 0)
   stopifnot(length(lower) == length(par.guess))
   stopifnot(length(upper) == length(par.guess))
 


### PR DESCRIPTION
This is just a proposal for now and a real implementation would take some time and effort in order to provide the full functionality including, perhaps, even plotting support.

But relaxing the condition on the lengths of `x` and `y` (requiring the former to be divisible by the latter), `bootstrap.nlsfit` in principle immediately supports fits in more than one dimension by simply concatenating the different X variables that one wants to use and writing an appropriate fit function which indexes into these (the necessary starting indices might be passed as a vector themselves, for example).